### PR TITLE
implementation of tokenPath() for FreeBSD

### DIFF
--- a/internal/authtokenservice/path_freebsd.go
+++ b/internal/authtokenservice/path_freebsd.go
@@ -1,0 +1,5 @@
+package authtoken
+
+func tokenPath () string {
+	return "/var/db/zerotier-one/authtoken.secret"
+}


### PR DESCRIPTION
Compilation on FreeBSD failed because there was no definition of tokenPath for it in internal/authtokenservice.

This patch just adds that with the right default path.